### PR TITLE
Build on stable

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8,10 +8,12 @@ use kiwi_debugger::RendererDebugger;
 use kiwi_ecs::{EntityData, SystemGroup, World};
 use kiwi_element::{element_component, Element, ElementComponentExt, Hooks};
 use kiwi_network::{
-    client::{GameClient, GameClientNetworkStats, GameClientRenderTarget, GameClientServerStats, GameClientView, UseOnce}, events::ServerEventRegistry
+    client::{GameClient, GameClientNetworkStats, GameClientRenderTarget, GameClientServerStats, GameClientView, UseOnce},
+    events::ServerEventRegistry,
 };
 use kiwi_std::{
-    asset_cache::{AssetCache, SyncAssetKeyExt}, friendly_id, Cb
+    asset_cache::{AssetCache, SyncAssetKeyExt},
+    cb, friendly_id, Cb,
 };
 use kiwi_ui::{use_window_physical_resolution, Dock, FocusRoot, StylesExt, Text, WindowSized};
 
@@ -133,7 +135,7 @@ fn GameView(_world: &mut World, hooks: &mut Hooks) -> Element {
     let show_debug = true;
     if show_debug {
         RendererDebugger {
-            get_state: Cb::new(move |cb| {
+            get_state: cb(move |cb| {
                 let mut game_state = state.game_state.lock();
                 let game_state = &mut *game_state;
                 cb(&mut game_state.renderer, &render_target.0, &mut game_state.world);
@@ -159,14 +161,14 @@ fn MainApp(world: &mut World, hooks: &mut Hooks, server_addr: SocketAddr, user_i
             server_addr,
             user_id,
             resolution,
-            on_disconnect: Cb::new(move || {}),
-            init_world: Cb::new(UseOnce::new(Box::new(move |world, _render_target| {
+            on_disconnect: cb(move || {}),
+            init_world: cb(UseOnce::new(Box::new(move |world, _render_target| {
                 world.add_resource(kiwi_network::events::event_registry(), Arc::new(ServerEventRegistry::new()));
             }))),
-            on_loaded: Cb::new(move |_game_state, _game_client| Ok(Box::new(|| {}))),
-            error_view: Cb(Arc::new(move |error| Dock(vec![Text::el("Error").header_style(), Text::el(error)]).el())),
-            systems_and_resources: Cb::new(|| (client_systems(), EntityData::new())),
-            create_rpc_registry: Cb::new(server::create_rpc_registry),
+            on_loaded: cb(move |_game_state, _game_client| Ok(Box::new(|| {}))),
+            error_view: cb(move |error| Dock(vec![Text::el("Error").header_style(), Text::el(error)]).el()),
+            systems_and_resources: cb(|| (client_systems(), EntityData::new())),
+            create_rpc_registry: cb(server::create_rpc_registry),
             on_in_entities: None,
             ui: GameView.el(),
         }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -13,7 +13,7 @@ use kiwi_network::{
 };
 use kiwi_std::{
     asset_cache::{AssetCache, SyncAssetKeyExt},
-    cb, friendly_id, Cb,
+    cb, friendly_id,
 };
 use kiwi_ui::{use_window_physical_resolution, Dock, FocusRoot, StylesExt, Text, WindowSized};
 
@@ -189,7 +189,18 @@ fn main() -> anyhow::Result<()> {
             ),
             (
                 LevelFilter::Warn,
-                &["kiwi_build", "kiwi_gpu", "kiwi_model", "kiwi_network", "kiwi_physics", "kiwi_std", "tracing", "wgpu_core", "wgpu_hal"],
+                &[
+                    "kiwi_build",
+                    "kiwi_gpu",
+                    "kiwi_model",
+                    "kiwi_network",
+                    "kiwi_physics",
+                    "kiwi_std",
+                    "naga",
+                    "tracing",
+                    "wgpu_core",
+                    "wgpu_hal",
+                ],
             ),
         ];
 

--- a/crates/asset_timeline/src/lib.rs
+++ b/crates/asset_timeline/src/lib.rs
@@ -9,7 +9,7 @@ use kiwi_renderer::color;
 use kiwi_std::{
     asset_cache::{AssetKey, AssetLifetime, AssetTimeline, AssetsTimeline},
     color::Color,
-    pretty_duration, to_byte_unit, Cb,
+    pretty_duration, to_byte_unit,
 };
 use kiwi_ui::{
     docking, fit_horizontal, height, margin, use_interval, width, Borders, Button, ButtonStyle, Dock, Docking, Editor, Fit, FlowColumn,

--- a/crates/asset_timeline/src/lib.rs
+++ b/crates/asset_timeline/src/lib.rs
@@ -7,10 +7,13 @@ use kiwi_ecs::World;
 use kiwi_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 use kiwi_renderer::color;
 use kiwi_std::{
-    asset_cache::{AssetKey, AssetLifetime, AssetTimeline, AssetsTimeline}, color::Color, pretty_duration, to_byte_unit, Cb
+    asset_cache::{AssetKey, AssetLifetime, AssetTimeline, AssetsTimeline},
+    color::Color,
+    pretty_duration, to_byte_unit, Cb,
 };
 use kiwi_ui::{
-    docking, fit_horizontal, height, margin, use_interval, width, Borders, Button, ButtonStyle, Dock, Docking, Editor, Fit, FlowColumn, FlowRow, Rectangle, StylesExt, Text, Tooltip, UIBase, UIExt, STREET
+    docking, fit_horizontal, height, margin, use_interval, width, Borders, Button, ButtonStyle, Dock, Docking, Editor, Fit, FlowColumn,
+    FlowRow, Rectangle, StylesExt, Text, Tooltip, UIBase, UIExt, STREET,
 };
 
 #[derive(Debug, Clone)]
@@ -140,7 +143,7 @@ impl ElementComponent for AssetTimelineVisualizer {
                     .style(ButtonStyle::Flat)
                     .el(),
                 ]),
-                FlowRow::el([Text::el("Limit:"), Option::<usize>::editor(limit, Cb(set_limit), Default::default())]),
+                FlowRow::el([Text::el("Limit:"), Option::<usize>::editor(limit, set_limit, Default::default())]),
             ])
             .keyboard(),
         );

--- a/crates/ecs_editor/examples/ecs_editor.rs
+++ b/crates/ecs_editor/examples/ecs_editor.rs
@@ -4,7 +4,7 @@ use kiwi_core::{async_ecs::async_run, camera::active_camera};
 use kiwi_ecs::{EntityData, World};
 use kiwi_ecs_editor::ECSEditor;
 use kiwi_element::{Element, ElementComponent, ElementComponentExt, Group, Hooks};
-use kiwi_std::{cb, Cb};
+use kiwi_std::cb;
 use kiwi_ui::{FocusRoot, ScrollArea, WindowSized};
 
 #[derive(Debug, Clone)]

--- a/crates/ecs_editor/examples/ecs_editor.rs
+++ b/crates/ecs_editor/examples/ecs_editor.rs
@@ -4,7 +4,7 @@ use kiwi_core::{async_ecs::async_run, camera::active_camera};
 use kiwi_ecs::{EntityData, World};
 use kiwi_ecs_editor::ECSEditor;
 use kiwi_element::{Element, ElementComponent, ElementComponentExt, Group, Hooks};
-use kiwi_std::Cb;
+use kiwi_std::{cb, Cb};
 use kiwi_ui::{FocusRoot, ScrollArea, WindowSized};
 
 #[derive(Debug, Clone)]
@@ -13,11 +13,11 @@ impl ElementComponent for ECSEditorUIWorld {
     fn render(self: Box<Self>, world: &mut World, _hooks: &mut Hooks) -> Element {
         let async_run = world.resource(async_run()).clone();
         ECSEditor {
-            get_world: Cb::new(move |run| {
+            get_world: cb(move |run| {
                 let run = run.clone();
                 async_run.run(move |world| run(world));
             }),
-            on_change: Cb::new(|world, diff| {
+            on_change: cb(|world, diff| {
                 diff.apply(world, EntityData::new(), false);
             }),
         }

--- a/crates/ecs_editor/src/lib.rs
+++ b/crates/ecs_editor/src/lib.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use kiwi_ecs::{with_component_registry, ComponentDesc, EntityData, EntityId, Query, World, WorldDiff};
 use kiwi_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 use kiwi_renderer::color;
-use kiwi_std::Cb;
+use kiwi_std::{cb, Cb};
 use kiwi_ui::{fit_horizontal, space_between_items, use_interval_deps, Button, ButtonStyle, Fit, FlowColumn, FlowRow, Text, UIExt, STREET};
 
 #[derive(Debug, Clone)]
@@ -32,7 +32,7 @@ impl ElementComponent for ECSEditor {
                 }
                 let set_entity_datas = set_entity_datas.clone();
                 let set_entities = set_entities.clone();
-                get_world(Cb::new(move |world| {
+                get_world(cb(move |world| {
                     set_entities(query.iter(world, None).map(|ea| ea.id()).collect());
                     set_entity_datas(
                         query.iter(world, None).take(20).map(|ea| (ea.id(), world.clone_entity(ea.id()).unwrap())).collect_vec(),

--- a/crates/editor_derive/src/test.rs
+++ b/crates/editor_derive/src/test.rs
@@ -53,7 +53,7 @@ fn test_struct() {
 
                 EditorRow::el(
                     "my_f32_field",
-                    <f32 as kiwi_ui::Editor>::edit_or_view(my_f32_field.clone(), on_change.clone().map(|on_change| kiwi_ui::Cb(::std::sync::Arc::new({
+                    <f32 as kiwi_ui::Editor>::edit_or_view(my_f32_field.clone(), on_change.clone().map(|on_change| kiwi_ui::cb_arc(::std::sync::Arc::new({
                         let my_option = my_option.clone();
                         move |v| {
                             on_change.0(Test { my_f32_field: v, my_option: my_option.clone() });
@@ -63,7 +63,7 @@ fn test_struct() {
 
                 EditorRow::el(
                     "my_option",
-                    <Option::<bool> as kiwi_ui::Editor>::edit_or_view(my_option.clone(), on_change.clone().map(|on_change| kiwi_ui::Cb(::std::sync::Arc::new({
+                    <Option::<bool> as kiwi_ui::Editor>::edit_or_view(my_option.clone(), on_change.clone().map(|on_change| kiwi_ui::cb_arc(::std::sync::Arc::new({
                         let my_f32_field = my_f32_field.clone();
                         move |v| {
                             on_change.0(Test { my_f32_field: my_f32_field.clone(), my_option: v });
@@ -103,9 +103,9 @@ fn test_enum() {
                             Test::Second { .. } => 1usize,
                             Test::Third(_) => 2usize,
                         },
-                        on_change: kiwi_ui::Cb(::std::sync::Arc::new(
+                        on_change: kiwi_ui::cb(
                             move |index| on_change.0(create_variant(index))
-                        )),
+                        ),
                         items: vec![
                             Text::el("First"),
                             Text::el("Second"),
@@ -126,7 +126,7 @@ fn test_enum() {
 
                     EditorRow::el(
                         "testy",
-                        <f32 as kiwi_ui::Editor>::edit_or_view(testy.clone(), on_change.clone().map(|on_change| kiwi_ui::Cb(::std::sync::Arc::new({
+                        <f32 as kiwi_ui::Editor>::edit_or_view(testy.clone(), on_change.clone().map(|on_change| kiwi_ui::cb_arc(::std::sync::Arc::new({
                             move |v| {
                                 on_change.0(Test::Second { testy: v });
                             }
@@ -139,7 +139,7 @@ fn test_enum() {
 
                     EditorRow::el(
                         "",
-                        <f32 as kiwi_ui::Editor>::edit_or_view(field_0.clone(), on_change.clone().map(|on_change| kiwi_ui::Cb(::std::sync::Arc::new({
+                        <f32 as kiwi_ui::Editor>::edit_or_view(field_0.clone(), on_change.clone().map(|on_change| kiwi_ui::cb_arc(::std::sync::Arc::new({
                             move |v| {
                                 on_change.0(Test::Third(v));
                             }
@@ -204,7 +204,7 @@ fn test_enum_inline() {
                 Test::First { testy } => FlowRow(vec![
 
                     Text::el("Hello "),
-                    <f32 as kiwi_ui::Editor>::edit_or_view(testy.clone(), on_change.clone().map(|on_change| kiwi_ui::Cb(::std::sync::Arc::new({
+                    <f32 as kiwi_ui::Editor>::edit_or_view(testy.clone(), on_change.clone().map(|on_change| kiwi_ui::cb_arc(::std::sync::Arc::new({
                         move |v| {
                             on_change.0(Test::First { testy: v });
                         }
@@ -217,9 +217,9 @@ fn test_enum_inline() {
                 if let Some(on_change) = on_change {
                     kiwi_ui::DropdownSelect {
                         content: field_editors,
-                        on_select: kiwi_ui::Cb(::std::sync::Arc::new(
+                        on_select: kiwi_ui::cb(
                             move |index| on_change.0(create_variant(index))
-                        )),
+                        ),
                         items: vec![
                             Test::view(create_variant(0usize), Default::default()),
                         ],
@@ -254,7 +254,7 @@ fn test_custom_editor() {
 
                 EditorRow::el(
                     "my_f32_field",
-                    test_editor(my_f32_field.clone(), on_change.clone().map(|on_change| kiwi_ui::Cb(::std::sync::Arc::new({
+                    test_editor(my_f32_field.clone(), on_change.clone().map(|on_change| kiwi_ui::cb_arc(::std::sync::Arc::new({
                         move |v| {
                             on_change.0(Test { my_f32_field: v });
                         }

--- a/crates/network/src/client.rs
+++ b/crates/network/src/client.rs
@@ -1,5 +1,8 @@
 use std::{
-    fmt::{Debug, Display}, net::SocketAddr, sync::Arc, time::Duration
+    fmt::{Debug, Display},
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
 };
 
 use anyhow::Context;
@@ -10,14 +13,21 @@ use kiwi_ecs::{components, query, EntityData, EntityId, SystemGroup, World, Worl
 use kiwi_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 use kiwi_renderer::RenderTarget;
 use kiwi_rpc::RpcRegistry;
-use kiwi_std::{fps_counter::FpsSample, log_result, to_byte_unit, CallbackFn, Cb};
+use kiwi_std::{cb, fps_counter::FpsSample, log_result, to_byte_unit, CallbackFn, Cb};
 use kiwi_ui::{Button, Centered, FlowColumn, FlowRow, Image, Text, Throbber};
 use parking_lot::Mutex;
 use quinn::{Connection, NewConnection};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    client_game_state::ClientGameState, create_client_endpoint_random_port, events::event_registry, is_remote_entity, log_network_result, player, protocol::{ClientInfo, ClientProtocol}, rpc_request, server::SharedServerState, user_id, NetworkError
+    client_game_state::ClientGameState,
+    create_client_endpoint_random_port,
+    events::event_registry,
+    is_remote_entity, log_network_result, player,
+    protocol::{ClientInfo, ClientProtocol},
+    rpc_request,
+    server::SharedServerState,
+    user_id, NetworkError,
 };
 
 components!("network", {
@@ -85,7 +95,7 @@ impl GameClient {
     ) -> Cb<impl Fn(Req)> {
         let runtime = runtime.clone();
         let (connection, rpc_registry) = (self.connection.clone(), self.rpc_registry.clone());
-        Cb::new(move |req| {
+        cb(move |req| {
             let (connection, rpc_registry) = (connection.clone(), rpc_registry.clone());
             runtime.spawn(async move {
                 log_network_result!(rpc_request(&connection, rpc_registry, func, req, Self::SIZE_LIMIT).await);

--- a/crates/network/src/events.rs
+++ b/crates/network/src/events.rs
@@ -3,7 +3,7 @@ use std::{any::type_name, io, sync::Arc};
 use anyhow::Context;
 use dashmap::DashMap;
 use kiwi_ecs::{components, query, EntityId, Resource, World};
-use kiwi_std::Cb;
+use kiwi_std::{cb, Cb};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
@@ -49,7 +49,7 @@ impl Handler {
             Ok(())
         };
 
-        Self { func: Cb(Arc::new(func)) }
+        Self { func: cb(func) }
     }
     pub fn run(&self, gs: &Mutex<ClientGameState>, event: Box<[u8]>) -> anyhow::Result<()> {
         (self.func)(&mut gs.lock().world, &event)

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(map_many_mut)]
 use std::{
     collections::HashMap, io::ErrorKind, net::{IpAddr, Ipv4Addr, SocketAddr}, sync::Arc, time::Duration
 };

--- a/crates/std/src/cb.rs
+++ b/crates/std/src/cb.rs
@@ -1,67 +1,42 @@
-use std::{
-    marker::Unsize, ops::{CoerceUnsized, Deref, DerefMut}, sync::Arc
-};
-
-/// This is just wrapping an Box, and it only exists because Box<dyn Fn..> doesn't implement Debug, so
-/// we're wrapping it with a CbBox to avoid having to handle that in all structs that implement Debug
-pub struct CbBox<T: ?Sized>(pub Box<T>);
-impl<T> CbBox<T> {
-    pub fn new(cb: T) -> Self {
-        Self(Box::new(cb))
-    }
-}
-
-impl<T: ?Sized> std::fmt::Debug for CbBox<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("CbBox").finish()
-    }
-}
-
-impl<T: ?Sized> Deref for CbBox<T> {
-    type Target = <Arc<T> as Deref>::Target;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-impl<T: ?Sized> DerefMut for CbBox<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.deref_mut()
-    }
-}
+use std::{ops::Deref, sync::Arc};
 
 pub type Callback<T, Ret = ()> = Cb<dyn Fn(T) -> Ret + Sync + Send>;
 
-/// This is just wrapping an Arc, and it only exists because Arc<dyn Fn..> doesn't implement Debug, so
-/// we're wrapping it with a Cb to avoid having to handle that in all structs that implement Debug
 #[derive(Default)]
-pub struct Cb<T: ?Sized>(pub Arc<T>);
-
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Cb<U>> for Cb<T> {}
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<CbBox<U>> for CbBox<T> {}
-
-impl<T> Cb<T> {
-    #[inline]
-    pub fn new(val: T) -> Self {
-        Self(Arc::new(val))
-    }
-}
-impl<T: ?Sized> std::fmt::Debug for Cb<T> {
+#[repr(transparent)]
+pub struct CbDebuggable<T: ?Sized>(pub T);
+impl<T: ?Sized> std::fmt::Debug for CbDebuggable<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Cb").finish()
     }
 }
-impl<T: ?Sized> Clone for Cb<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-impl<T: ?Sized> Deref for Cb<T> {
-    type Target = <Arc<T> as Deref>::Target;
+impl<T: ?Sized> Deref for CbDebuggable<T> {
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.0.deref()
+        &self.0
     }
+}
+
+pub type Cb<T> = Arc<CbDebuggable<T>>;
+
+/// Helper for constructing a `Cb`.
+///
+/// This is just wrapping an Arc, and it only exists because Arc<dyn Fn..> doesn't implement Debug, so
+/// we're wrapping it with a Cb to avoid having to handle that in all structs that implement Debug
+pub fn cb<T>(f: T) -> Cb<T> {
+    Arc::new(CbDebuggable(f))
+}
+
+/// Helper for constructing a `Cb`.
+///
+/// Sometimes, it is necessary to construct the contained type more directly (due to type inference
+/// issues or unsizing). This provides a way to do that.
+pub fn cb_arc<T: ?Sized>(f: Arc<T>) -> Cb<T> {
+    assert_eq!(Arc::strong_count(&f), 1);
+
+    let inner = Arc::into_raw(f);
+    unsafe { Arc::from_raw(inner as *const CbDebuggable<T>) }
 }
 
 pub fn log_error(err: &anyhow::Error) {
@@ -71,7 +46,7 @@ pub fn log_error(err: &anyhow::Error) {
     tracing::error!("{:?}", err);
 }
 
-pub type CallbackFn<T, U = ()> = Arc<dyn Fn(T) -> U + Sync + Send + 'static>;
+pub type CallbackFn<T, U = ()> = Cb<dyn Fn(T) -> U + Sync + Send + 'static>;
 pub type CallbackBox<T, U = ()> = Box<dyn Fn(T) -> U + Sync + Send + 'static>;
 
 pub type CellFn<T, U = ()> = dyn Fn(&mut T) -> U + Send + Sync;

--- a/crates/std/src/lib.rs
+++ b/crates/std/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "cb", feature(coerce_unsized))]
-#![cfg_attr(feature = "cb", feature(unsize))]
 use std::borrow::Cow;
 
 #[cfg(feature = "uncategorized")]

--- a/crates/ui/examples/element_editor.rs
+++ b/crates/ui/examples/element_editor.rs
@@ -59,7 +59,7 @@ impl ElementComponent for Example {
     fn render(self: Box<Self>, _world: &mut World, hooks: &mut Hooks) -> Element {
         let (state, set_state) = hooks.use_state(MyStruct::new());
         FocusRoot(vec![ScrollArea(
-            FlowColumn(vec![MyStruct::editor(state.clone(), Cb(set_state), Default::default()), Text::el(format!("{state:#?}"))])
+            FlowColumn(vec![MyStruct::editor(state.clone(), set_state, Default::default()), Text::el(format!("{state:#?}"))])
                 .el()
                 .set(space_between_items(), STREET),
         )

--- a/crates/ui/examples/input.rs
+++ b/crates/ui/examples/input.rs
@@ -19,26 +19,26 @@ impl ElementComponent for Example {
         let (minimal_list, set_minimal_list) = hooks.use_state(vec!["First".to_string(), "Second".to_string()]);
         let row = |name, editor| FlowRow(vec![Text::el(name).set(min_width(), 110.), editor]).el();
         FocusRoot(vec![FlowColumn(vec![
-            row("TextInput", TextInput::new(text, Cb(set_text)).el()),
+            row("TextInput", TextInput::new(text, set_text).el()),
             // Button::new("Focus test", |_| {}).hotkey(winit::event::VirtualKeyCode::Back).el(),
             row(
                 "DropDownSelect",
                 DropdownSelect {
                     content: Text::el("Select"),
-                    on_select: Cb::new(|_| {}),
+                    on_select: cb(|_| {}),
                     items: vec![Text::el("First"), Text::el("Second")],
                     inline: false,
                 }
                 .el(),
             ),
-            row("Vec3", Vec3::editor(vector3, Cb(set_vector3), Default::default())),
-            row("IndexMap", IndexMap::editor(index_map, Cb(set_index_map), Default::default())),
-            row("ListEditor", ListEditor { value: list, on_change: Some(Cb(set_list)) }.el()),
+            row("Vec3", Vec3::editor(vector3, set_vector3, Default::default())),
+            row("IndexMap", IndexMap::editor(index_map, set_index_map, Default::default())),
+            row("ListEditor", ListEditor { value: list, on_change: Some(set_list) }.el()),
             row(
                 "MinimalListEditor",
                 MinimalListEditor {
                     value: minimal_list,
-                    on_change: Some(Cb(set_minimal_list)),
+                    on_change: Some(set_minimal_list),
                     item_opts: Default::default(),
                     add_presets: None,
                     add_title: "Add".to_string(),

--- a/crates/ui/examples/screens.rs
+++ b/crates/ui/examples/screens.rs
@@ -17,7 +17,7 @@ impl ElementComponent for RootScreen {
             Button::new("Open sub screen", move |_| {
                 set_screen(Some(
                     SubScreen {
-                        on_back: Cb::new({
+                        on_back: cb({
                             let set_screen = set_screen.clone();
                             move || {
                                 set_screen(None);
@@ -52,7 +52,7 @@ impl ElementComponent for SubScreen {
                 move |_| {
                     set_screen(Some(
                         SubScreen {
-                            on_back: Cb::new({
+                            on_back: cb({
                                 let set_screen = set_screen.clone();
                                 move || {
                                     set_screen(None);
@@ -67,12 +67,12 @@ impl ElementComponent for SubScreen {
             Button::new("Prompt", {
                 let set_screen = set_screen.clone();
                 move |_| {
-                    set_screen(Some(Prompt::new("Testy", Cb(set_screen.clone()), |_, _| {}).el()));
+                    set_screen(Some(Prompt::new("Testy", set_screen.clone(), |_, _| {}).el()));
                 }
             })
             .el(),
             Button::new("Editor Prompt", move |_| {
-                set_screen(Some(EditorPrompt::new("Testy", "Something".to_string(), Cb(set_screen.clone()), |_, _| {}).el()));
+                set_screen(Some(EditorPrompt::new("Testy", "Something".to_string(), set_screen.clone(), |_, _| {}).el()));
             })
             .el(),
         ])

--- a/crates/ui/examples/slider.rs
+++ b/crates/ui/examples/slider.rs
@@ -16,7 +16,7 @@ impl ElementComponent for Example {
         FocusRoot::el([FlowColumn::el([
             Slider {
                 value: f32_value,
-                on_change: Some(Cb(set_f32_value)),
+                on_change: Some(set_f32_value),
                 min: 0.,
                 max: 100.,
                 width: 100.,
@@ -27,7 +27,7 @@ impl ElementComponent for Example {
             .el(),
             Slider {
                 value: f32_exp_value,
-                on_change: Some(Cb(set_f32_exp_value)),
+                on_change: Some(set_f32_exp_value),
                 min: 0.1,
                 max: 1000.,
                 width: 100.,
@@ -38,7 +38,7 @@ impl ElementComponent for Example {
             .el(),
             IntegerSlider {
                 value: i32_value,
-                on_change: Some(Cb(set_i32_value)),
+                on_change: Some(set_i32_value),
                 min: 0,
                 max: 100,
                 width: 100.,

--- a/crates/ui/examples/state.rs
+++ b/crates/ui/examples/state.rs
@@ -91,14 +91,10 @@ impl ElementComponent for Main {
 
         let (show_b, set_show_b) = hooks.use_state(true);
         if show_b {
-            FlowColumn::el([
-                A { value, set_value: Cb(set_value) }.el(),
-                Button::new("Hide", move |_| set_show_b(false)).el(),
-                B { shared }.el(),
-            ])
+            FlowColumn::el([A { value, set_value }.el(), Button::new("Hide", move |_| set_show_b(false)).el(), B { shared }.el()])
         } else {
             FlowColumn::el([
-                A { value, set_value: Cb(set_value) }.el(),
+                A { value, set_value }.el(),
                 Button::new("Show", move |_| set_show_b(true)).el(),
                 // B { shared }.el(),
             ])

--- a/crates/ui/examples/todo.rs
+++ b/crates/ui/examples/todo.rs
@@ -12,8 +12,8 @@ impl ElementComponent for TodoList {
         let (dishes, set_dishes) = hooks.use_state(false);
         let (laundry, set_laundry) = hooks.use_state(false);
         FlowColumn(vec![
-            FlowRow(vec![Checkbox { value: laundry, on_change: Cb(set_laundry) }.el(), Text::el("Laundry")]).el(),
-            FlowRow(vec![Checkbox { value: dishes, on_change: Cb(set_dishes) }.el(), Text::el("Dishes")]).el(),
+            FlowRow(vec![Checkbox { value: laundry, on_change: set_laundry }.el(), Text::el("Laundry")]).el(),
+            FlowRow(vec![Checkbox { value: dishes, on_change: set_dishes }.el(), Text::el("Dishes")]).el(),
             match (dishes, laundry) {
                 (true, true) => Text::el("Yay!"),
                 (false, false) => Text::el("Stop watching Netflix dude..."),

--- a/crates/ui/examples/ui.rs
+++ b/crates/ui/examples/ui.rs
@@ -9,7 +9,8 @@ use kiwi_element::{Element, ElementComponent, ElementComponentExt, Hooks};
 use kiwi_renderer::color;
 use kiwi_std::color::Color;
 use kiwi_ui::{
-    layout::{height, width}, Throbber, *
+    layout::{height, width},
+    Throbber, *,
 };
 
 #[derive(Debug, Clone)]
@@ -56,7 +57,7 @@ struct InputTest;
 impl ElementComponent for InputTest {
     fn render(self: Box<Self>, _world: &mut World, hooks: &mut Hooks) -> Element {
         let (value, set_value) = hooks.use_state("".to_string());
-        FlowColumn::el([Throbber.el(), TextInput::new(value, Cb(set_value)).el()])
+        FlowColumn::el([Throbber.el(), TextInput::new(value, set_value).el()])
     }
 }
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,7 +1,10 @@
 use std::{
-    collections::HashMap, fmt::Debug, sync::{
-        atomic::{AtomicBool, Ordering}, Arc
-    }
+    collections::HashMap,
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use closure::closure;
@@ -13,9 +16,10 @@ pub use kiwi_editor_derive::ElementEditor;
 pub use kiwi_element as element;
 use kiwi_element::{define_el_function_for_vec_element_newtype, element_component, Element, ElementComponent, ElementComponentExt, Hooks};
 use kiwi_input::{
-    on_app_mouse_input, on_app_mouse_motion, on_app_mouse_wheel, picking::{mouse_pickable, on_mouse_enter, on_mouse_hover, on_mouse_input, on_mouse_leave, on_mouse_wheel}
+    on_app_mouse_input, on_app_mouse_motion, on_app_mouse_wheel,
+    picking::{mouse_pickable, on_mouse_enter, on_mouse_hover, on_mouse_input, on_mouse_leave, on_mouse_wheel},
 };
-pub use kiwi_std::Cb;
+pub use kiwi_std::{cb, cb_arc, Cb};
 use kiwi_std::{color::Color, shapes::AABB};
 use parking_lot::Mutex;
 use winit::event::{ElementState, ModifiersState, MouseButton, MouseScrollDelta, WindowEvent};
@@ -290,7 +294,7 @@ impl ElementComponent for FocusRoot {
 
 impl Default for HighjackMouse {
     fn default() -> Self {
-        Self { on_mouse_move: Cb::new(|_, _, _| {}), on_click: Cb::new(|_| {}), hide_mouse: false }
+        Self { on_mouse_move: cb(|_, _, _| {}), on_click: cb(|_| {}), hide_mouse: false }
     }
 }
 
@@ -521,7 +525,7 @@ impl<
     pub fn to_editor_prompt_screen_callback(
         &self,
         title: impl Into<String>,
-        set_screen: Arc<dyn Fn(Option<Element>) + Send + Sync>,
+        set_screen: Cb<dyn Fn(Option<Element>) + Send + Sync>,
     ) -> impl Fn() + Sync + Send {
         let value = self.clone();
         let title = title.into();
@@ -530,12 +534,12 @@ impl<
                 EditorPrompt {
                     title: title.clone(),
                     value: value.get_cloned(),
-                    set_screen: Cb(set_screen.clone()),
-                    on_ok: Cb::new({
+                    set_screen: set_screen.clone(),
+                    on_ok: cb({
                         let value = value.clone();
                         move |_, new_value| value.set(new_value)
                     }),
-                    on_cancel: Some(Cb::new(|_| {})),
+                    on_cancel: Some(cb(|_| {})),
                     validator: None,
                 }
                 .el(),

--- a/crates/ui/src/prompt.rs
+++ b/crates/ui/src/prompt.rs
@@ -1,9 +1,10 @@
 use kiwi_ecs::{ComponentValue, World};
 use kiwi_element::{element_component, Element, ElementComponentExt, Hooks};
-use kiwi_std::Cb;
+use kiwi_std::{cb, Cb};
 
 use crate::{
-    align_vertical, space_between_items, Button, ButtonStyle, DialogScreen, Editor, FlowColumn, FlowRow, ScrollArea, StylesExt, Text, TextInput, STREET
+    align_vertical, space_between_items, Button, ButtonStyle, DialogScreen, Editor, FlowColumn, FlowRow, ScrollArea, StylesExt, Text,
+    TextInput, STREET,
 };
 
 #[element_component]
@@ -76,7 +77,7 @@ pub fn Prompt(
     DialogScreen(
         FlowColumn::el([
             Text::el(title).header_style(),
-            TextInput::new(value.clone(), Cb(set_value)).placeholder(placeholder.or(Some("Enter value".to_string()))).el(),
+            TextInput::new(value.clone(), set_value).placeholder(placeholder.or(Some("Enter value".to_string()))).el(),
             FlowRow::el([
                 Button::new("Ok", move |world| {
                     on_ok(world, value.clone());
@@ -110,7 +111,7 @@ impl Prompt {
         Self {
             title: title.into(),
             placeholder: None,
-            on_ok: Cb::new(move |world, value| {
+            on_ok: cb(move |world, value| {
                 on_ok(world, value);
                 set_screen(None);
             }),
@@ -126,14 +127,14 @@ impl Prompt {
         Self {
             title: title.into(),
             placeholder: None,
-            on_ok: Cb::new({
+            on_ok: cb({
                 let set_screen = set_screen.clone();
                 move |world, value| {
                     on_ok(world, value);
                     set_screen(None);
                 }
             }),
-            on_cancel: Some(Cb::new(move |_| set_screen(None))),
+            on_cancel: Some(cb(move |_| set_screen(None))),
         }
     }
     pub fn placeholder(mut self, placeholder: impl Into<String>) -> Self {
@@ -158,7 +159,7 @@ pub fn EditorPrompt<T: Editor + std::fmt::Debug + Clone + ComponentValue>(
         ScrollArea(
             FlowColumn::el([
                 Text::el(title).header_style(),
-                value.clone().editor(Cb(set_value), Default::default()),
+                value.clone().editor(set_value, Default::default()),
                 FlowRow(vec![
                     Button::new("Ok", {
                         let set_screen = set_screen.clone();
@@ -200,6 +201,6 @@ impl<T: Editor + std::fmt::Debug + Clone + ComponentValue> EditorPrompt<T> {
         set_screen: Cb<dyn Fn(Option<Element>) + Sync + Send>,
         on_ok: impl Fn(&mut World, T) + Sync + Send + 'static,
     ) -> Self {
-        Self { title: title.into(), value, set_screen, on_ok: Cb::new(on_ok), on_cancel: None, validator: None }
+        Self { title: title.into(), value, set_screen, on_ok: cb(on_ok), on_cancel: None, validator: None }
     }
 }

--- a/crates/ui/src/tabs.rs
+++ b/crates/ui/src/tabs.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use closure::closure;
 use kiwi_ecs::World;
 use kiwi_element::{Element, ElementComponent, ElementComponentExt, Hooks};
-use kiwi_std::Cb;
+use kiwi_std::{cb, Cb};
 
 use crate::{space_between_items, Button, FlowColumn, FlowRow, STREET};
 
@@ -40,19 +40,18 @@ impl<T: ToString + PartialEq + Default + Clone + Debug + Sync + Send + 'static> 
     }
 
     pub fn with_tab(mut self, tab: T, callback: impl Fn() -> Element + Sync + Send + 'static) -> Self {
-        self.tabs.push((tab, Cb::new(callback)));
+        self.tabs.push((tab, cb(callback)));
         self
     }
 }
 impl<T: ToString + PartialEq + Default + Clone + Debug + Sync + Send + 'static> ElementComponent for Tabs<T> {
     fn render(self: Box<Self>, _: &mut World, hooks: &mut Hooks) -> Element {
         let (value, set_value) = hooks.use_state(T::default());
-        let selected_tab = self.tabs.iter().find(|it| it.0 == value).map(|it| it.1.clone()).unwrap_or(Cb::new(|| Element::new()));
+        let selected_tab = self.tabs.iter().find(|it| it.0 == value).map(|it| it.1.clone()).unwrap_or(cb(|| Element::new()));
         let key = value.to_string();
 
         FlowColumn::el([
-            TabBar { tabs: self.tabs.iter().map(|it| it.0.clone()).collect(), value, on_change: Cb::new(move |value| set_value(value)) }
-                .el(),
+            TabBar { tabs: self.tabs.iter().map(|it| it.0.clone()).collect(), value, on_change: cb(move |value| set_value(value)) }.el(),
             selected_tab().key(key),
         ])
         .set(space_between_items(), STREET)

--- a/crates/ui/src/text_input.rs
+++ b/crates/ui/src/text_input.rs
@@ -7,9 +7,10 @@ use kiwi_ecs::{EntityId, World};
 use kiwi_element::{element_component, Element, ElementComponentExt, Hooks};
 use kiwi_input::{on_app_keyboard_input, on_app_received_character, KeyboardEvent};
 use kiwi_renderer::color;
-use kiwi_std::Cb;
+use kiwi_std::{cb, Cb};
 use winit::{
-    event::{ElementState, VirtualKeyCode}, window::CursorIcon
+    event::{ElementState, VirtualKeyCode},
+    window::CursorIcon,
 };
 
 use super::{Editor, EditorOpts, Focus, Text, UIExt};
@@ -114,7 +115,7 @@ impl TextInput {
         Self { value, on_change, on_submit: None, password: false, placeholder: None }
     }
     pub fn on_submit(mut self, on_submit: impl Fn(String) + Sync + Send + 'static) -> Self {
-        self.on_submit = Some(Cb(Arc::new(on_submit)));
+        self.on_submit = Some(cb(on_submit));
         self
     }
     pub fn placeholder<T: Into<String>>(mut self, placeholder: Option<T>) -> Self {

--- a/crates/world_audio/src/sounds.rs
+++ b/crates/world_audio/src/sounds.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use kiwi_audio::{hrtf::HrtfLib, Attenuation, AudioEmitter, AudioListener, AudioMixer, Sound, Source};
 use kiwi_ecs::{components, query, EntityId, Resource, World};
 use kiwi_element::ElementComponentExt;
-use kiwi_std::Cb;
+use kiwi_std::{cb, Cb};
 use kiwi_ui::{
     graph::{Graph, GraphStyle},
     Editor, FlowColumn,

--- a/crates/world_audio/src/sounds.rs
+++ b/crates/world_audio/src/sounds.rs
@@ -9,7 +9,8 @@ use kiwi_ecs::{components, query, EntityId, Resource, World};
 use kiwi_element::ElementComponentExt;
 use kiwi_std::Cb;
 use kiwi_ui::{
-    graph::{Graph, GraphStyle}, Editor, FlowColumn
+    graph::{Graph, GraphStyle},
+    Editor, FlowColumn,
 };
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -30,7 +31,7 @@ pub struct AttenuationEditorVisual(Attenuation);
 
 impl Editor for AttenuationEditorVisual {
     fn editor(self, on_change: Cb<dyn Fn(Self) + Sync + Send>, opts: kiwi_ui::EditorOpts) -> kiwi_element::Element {
-        let editor = Attenuation::editor(*self, Cb::new(move |v| on_change(v.into())), opts);
+        let editor = Attenuation::editor(*self, cb(move |v| on_change(v.into())), opts);
 
         let x_max = self.inverse(0.01);
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2022-12-08"


### PR DESCRIPTION
Fixes #31.

Had to remove the four features in use. `cursor_remaining` was simple to do; `map_many_mut` required some rearranging of one function - but the biggest was removing the use of `unsize` and `coerce_unsized` for `Cb`.

To do this, I tried out a few different solutions, but settled on changing `Cb` to be an alias for `Arc<Debuggable<T>>`, and created `cb` and `cb_arc` to create `Cb`s (analogous to `Cb::new` and `Cb(/* some arc */)`) respectively. It would have been nice to do it with a newtype as before, but type inference appears to fail in that case.

This now builds on stable Rust 1.67.0, no tricks involved. Probably builds on versions earlier than that, too, but not by much.

Mild annoyance: stable `rustfmt` does not support the import formatting settings, so the imports will be reformatted to the standard (as you can see in the files that were edited)